### PR TITLE
Introduce AssuredPublisher

### DIFF
--- a/assured_publisher.go
+++ b/assured_publisher.go
@@ -1,0 +1,70 @@
+package rabbit
+
+import (
+	"github.com/streadway/amqp"
+	"log"
+	"time"
+)
+
+//AssuredPublisher allows you to publish events to RabbitMQ with implicit delivery confirmation
+type AssuredPublisher struct {
+	Publisher
+
+	confirmation chan amqp.Confirmation
+}
+
+// NewAssuredPublisher constructs a new AssuredPublisher instance
+func NewAssuredPublisher() *AssuredPublisher {
+	publisher := &AssuredPublisher{}
+	publisher.confirmation = publisher.NotifyPublish(make(chan amqp.Confirmation, 1))
+	for err := publisher.Confirm(false); err != nil; err = publisher.Confirm(false) {
+		logError(err, "Can't setup confirmations for a publisher")
+		time.Sleep(1)
+	}
+	return publisher
+}
+
+// Publish pushes items on to a RabbitMQ Queue.
+// For AssuredPublisher it waits for delivery confirmaiton and retries on failures
+func (p *AssuredPublisher) Publish(message string, subscriber *Subscriber) error {
+	for {
+		if err := (&p.Publisher).Publish(message, subscriber); err != nil {
+			log.Printf("Error on pushing into RabbitMQ: %v", err)
+			continue
+		}
+		if p.waitForConfirmation() {
+			break
+		}
+	}
+	return nil
+}
+
+// PublishBytes is the same as Publish but accepts a []byte instead of a string.
+// For AssuredPublisher it waits for delivery confirmaiton and retries on failures
+func (p *AssuredPublisher) PublishBytes(message []byte, subscriber *Subscriber) {
+	for {
+		if err := (&p.Publisher).PublishBytes(message, subscriber); err != nil {
+			log.Printf("Error on pushing into RabbitMQ: %v", err)
+			continue
+		}
+		if p.waitForConfirmation() {
+			break
+		}
+	}
+}
+
+func (p *AssuredPublisher) waitForConfirmation() bool {
+	log.Printf("Waiting for confirmation")
+	timeout := time.After(10 * time.Second)
+	select {
+	case confirmed := <-p.confirmation:
+		if confirmed.Ack {
+			return true
+		}
+		log.Printf("Unknown error (RabbitMQ Ack is false)")
+		return false
+	case <-timeout:
+		log.Printf("RabbitMQ Timeout")
+		return false
+	}
+}

--- a/assured_publisher.go
+++ b/assured_publisher.go
@@ -9,14 +9,12 @@ import (
 //AssuredPublisher allows you to publish events to RabbitMQ with implicit delivery confirmation
 type AssuredPublisher struct {
 	Publisher
-
-	confirmation chan amqp.Confirmation
 }
 
 // NewAssuredPublisher constructs a new AssuredPublisher instance
 func NewAssuredPublisher() *AssuredPublisher {
 	publisher := &AssuredPublisher{}
-	publisher.confirmation = publisher.NotifyPublish(make(chan amqp.Confirmation, 1))
+	publisher.NotifyPublish(make(chan amqp.Confirmation, 1))
 	for err := publisher.Confirm(false); err != nil; err = publisher.Confirm(false) {
 		logError(err, "Can't setup confirmations for a publisher")
 		time.Sleep(1)
@@ -57,7 +55,7 @@ func (p *AssuredPublisher) waitForConfirmation() bool {
 	log.Printf("Waiting for confirmation")
 	timeout := time.After(10 * time.Second)
 	select {
-	case confirmed := <-p.confirmation:
+	case confirmed := <-p._notifyPublish[0]:
 		if confirmed.Ack {
 			return true
 		}

--- a/assured_publisher_test.go
+++ b/assured_publisher_test.go
@@ -1,0 +1,27 @@
+package rabbit_test
+
+import (
+	"testing"
+
+	"github.com/brettallred/go-rabbit"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPublishAssured(t *testing.T) {
+	var subscriber = rabbit.Subscriber{
+		Concurrency: 5,
+		Durable:     true,
+		Exchange:    "events",
+		Queue:       "test.publishsample.event.created",
+		RoutingKey:  "publishsample.event.created",
+	}
+	assert := assert.New(t)
+
+	message := "Test Message"
+	publisher := rabbit.NewAssuredPublisher()
+	publisher.Publish(message, &subscriber)
+
+	var result string
+	result, _ = rabbit.Pop(&subscriber)
+	assert.Equal(message, result)
+}

--- a/assured_publisher_test.go
+++ b/assured_publisher_test.go
@@ -19,9 +19,10 @@ func TestPublishAssured(t *testing.T) {
 
 	message := "Test Message"
 	publisher := rabbit.NewAssuredPublisher()
-	publisher.Publish(message, &subscriber)
+	ok := publisher.Publish(message, &subscriber, make(chan bool))
 
 	var result string
 	result, _ = rabbit.Pop(&subscriber)
 	assert.Equal(message, result)
+	assert.True(ok)
 }


### PR DESCRIPTION
Introduce AssuredPublisher, i.e. a publisher that waits for delivery confirmation and retries the publishing if an error occurs