### PR TITLE
refactor createChannel to use return error pattern

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -5,15 +5,16 @@ import (
 	"log"
 )
 
-func createChannel(conn *amqp.Connection, autoCloseConnection bool) *amqp.Channel {
+func createChannel(conn *amqp.Connection, autoCloseConnection bool) (*amqp.Channel, error) {
 	if conn == nil {
 		log.Printf("Failed to open a channel: no connection")
-		return nil
+		return nil, nil //TODO Remove this guard clause
 	}
+
 	channel, err := conn.Channel()
+
 	if err != nil {
-		logError(err, "Failed to open a channel")
-		return nil
+		return nil, err
 	}
 
 	if autoCloseConnection {
@@ -31,5 +32,5 @@ func createChannel(conn *amqp.Connection, autoCloseConnection bool) *amqp.Channe
 		go errorHandler()
 	}
 
-	return channel
+	return channel, nil
 }

--- a/channel.go
+++ b/channel.go
@@ -2,35 +2,29 @@ package rabbit
 
 import (
 	"github.com/streadway/amqp"
-	"log"
 )
 
-func createChannel(conn *amqp.Connection, autoCloseConnection bool) (*amqp.Channel, error) {
-	if conn == nil {
-		log.Printf("Failed to open a channel: no connection")
-		return nil, nil //TODO Remove this guard clause
-	}
-
+func createConnectionClosingChannel(conn *amqp.Connection) (*amqp.Channel, error) {
 	channel, err := conn.Channel()
 
 	if err != nil {
-		return nil, err
+		return channel, err
 	}
 
-	if autoCloseConnection {
-		errorChannel := make(chan *amqp.Error, 1)
-		errorHandler := func() {
-			select {
-			case <-errorChannel:
-				lock.Lock()
-				defer lock.Unlock()
-				_connection.Close()
-				return
-			}
-		}
-		channel.NotifyClose(errorChannel)
-		go errorHandler()
-	}
+	errorChannel := make(chan *amqp.Error, 1)
+	channel.NotifyClose(errorChannel)
+
+	go closeConnectionOnChannelNotifyClose(errorChannel)
 
 	return channel, nil
+}
+
+func closeConnectionOnChannelNotifyClose(errorChannel chan *amqp.Error) {
+	select {
+	case <-errorChannel:
+		lock.Lock()
+		defer lock.Unlock()
+		_connection.Close()
+		return
+	}
 }

--- a/connection.go
+++ b/connection.go
@@ -34,7 +34,7 @@ func handleConnectionError(myConnection *amqp.Connection) {
 		if _connection != nil && subscribersStarted {
 			err := StartSubscribers()
 			if err != nil {
-				log.Printf("Erron on subscribing to RabbitMQ: %s", err.Error())
+				log.Printf("Error on subscribing to RabbitMQ: %s", err.Error())
 				c := _connection
 				defer c.Close()
 			}
@@ -112,7 +112,7 @@ func handlePublisherConnectionError(connection *Connection, myConnection *amqp.C
 	}
 }
 
-func (connection *Connection) connect() error {
+func (connection *Connection) connect() {
 	connection.connection = nil
 	var c *amqp.Connection
 	var err error
@@ -142,5 +142,4 @@ func (connection *Connection) connect() error {
 	}
 	connection.connection.NotifyClose(errorChannel)
 	go errorHandler(c)
-	return nil
 }

--- a/exchange.go
+++ b/exchange.go
@@ -14,9 +14,5 @@ func createExchange(channel *amqp.Channel, subscriber *Subscriber) error {
 		false,   // no-wait
 		nil,     // arguments
 	)
-	if err != nil {
-		logError(err, "Failed to declare an exchange")
-		return nil
-	}
 	return err
 }

--- a/pop.go
+++ b/pop.go
@@ -16,7 +16,7 @@ func InitPop() {
 	}
 
 	if popChannel == nil {
-		popChannel = createChannel(popConnection, false)
+		popChannel, _ = createChannel(popConnection, false)
 	}
 }
 

--- a/pop.go
+++ b/pop.go
@@ -16,7 +16,7 @@ func InitPop() {
 	}
 
 	if popChannel == nil {
-		popChannel, _ = createChannel(popConnection, false)
+		popChannel, _ = popConnection.Channel()
 	}
 }
 

--- a/publisher.go
+++ b/publisher.go
@@ -40,7 +40,7 @@ func (p *Publisher) GetChannel() *amqp.Channel {
 
 func (p *Publisher) openChannel() (err error) {
 	c := publisherConnection.GetConnection()
-	p._channel, err = createChannel(c, false)
+	p._channel, err = c.Channel()
 
 	if err != nil {
 		log.Printf("Can't create a RabbitMQ channel for publisher")

--- a/publisher.go
+++ b/publisher.go
@@ -38,13 +38,15 @@ func (p *Publisher) GetChannel() *amqp.Channel {
 	return p._channel
 }
 
-func (p *Publisher) openChannel() error {
+func (p *Publisher) openChannel() (err error) {
 	c := publisherConnection.GetConnection()
-	p._channel = createChannel(c, false)
-	if p._channel == nil {
+	p._channel, err = createChannel(c, false)
+
+	if err != nil {
 		log.Printf("Can't create a RabbitMQ channel for publisher")
 		return errors.New("Can't create channel for publisher")
 	}
+
 	for i := range p._notifyPublish {
 		p._channel.NotifyPublish(p._notifyPublish[i])
 	}

--- a/queue.go
+++ b/queue.go
@@ -1,18 +1,11 @@
 package rabbit
 
 import (
-	"errors"
 	"github.com/streadway/amqp"
-	"log"
 )
 
-func createQueue(channel *amqp.Channel, subscriber *Subscriber) (*amqp.Queue, error) {
-	if channel == nil {
-		errorMessage := "Failed to declare a queue: no connection"
-		log.Printf(errorMessage)
-		return nil, errors.New(errorMessage)
-	}
-	queue, err := channel.QueueDeclare(
+func createQueue(channel *amqp.Channel, subscriber *Subscriber) error {
+	_, err := channel.QueueDeclare(
 		subscriber.Queue,      // name
 		subscriber.Durable,    // durable
 		subscriber.AutoDelete, // delete when usused
@@ -20,10 +13,7 @@ func createQueue(channel *amqp.Channel, subscriber *Subscriber) (*amqp.Queue, er
 		false, // no-wait
 		nil,   // arguments
 	)
-	if err != nil {
-		logError(err, "Failed to declare an queue")
-	}
-	return &queue, err
+	return err
 }
 
 func bindQueue(channel *amqp.Channel, subscriber *Subscriber) error {

--- a/subscriber.go
+++ b/subscriber.go
@@ -65,10 +65,12 @@ func startSubscribers(conn *amqp.Connection) error {
 				subscriber.AutoDelete,
 			)
 
-			channel := createChannel(conn, true)
-			if channel == nil {
+			channel, err := createChannel(conn, true)
+
+			if err != nil {
 				return errors.New("Failed to start subscriber: can't create a channel")
 			}
+
 			if err := createExchange(channel, &subscriber); err != nil {
 				log.Printf("Failed to start subscriber: %v", err.Error())
 				return err
@@ -128,10 +130,12 @@ func DeleteQueue(s Subscriber) error {
 		return errors.New(errorMessage)
 	}
 
-	channel := createChannel(conn, false)
-	if channel == nil {
+	channel, err := createChannel(conn, false)
+
+	if err != nil {
 		return errors.New("Can't delete a queue: can't create a channel")
 	}
+
 	return deleteQueue(channel, &s)
 }
 


### PR DESCRIPTION
We were breaking the error handling pattern in go.  This is a very small change fixes the pattern for the createChannel method.