### PR TITLE
Custom RabbitMQ connections for publishers + batch confirmations in AssuredPublisher + bugfixes

### DIFF
--- a/assured_publisher.go
+++ b/assured_publisher.go
@@ -1,9 +1,10 @@
 package rabbit
 
 import (
-	"github.com/streadway/amqp"
 	"log"
 	"time"
+
+	"github.com/streadway/amqp"
 )
 
 //AssuredPublisher allows you to publish events to RabbitMQ with implicit delivery confirmation
@@ -11,14 +12,25 @@ type AssuredPublisher struct {
 	Publisher
 }
 
-// NewAssuredPublisher constructs a new AssuredPublisher instance
-func NewAssuredPublisher() *AssuredPublisher {
-	publisher := &AssuredPublisher{}
-	publisher.NotifyPublish(make(chan amqp.Confirmation, 1))
-	for err := publisher.Confirm(false); err != nil; err = publisher.Confirm(false) {
+func (p *AssuredPublisher) construct() {
+	p.NotifyPublish(make(chan amqp.Confirmation, 1))
+	for err := p.Confirm(false); err != nil; err = p.Confirm(false) {
 		logError(err, "Can't setup confirmations for a publisher")
 		time.Sleep(1)
 	}
+}
+
+// NewAssuredPublisher constructs a new AssuredPublisher instance
+func NewAssuredPublisher() *AssuredPublisher {
+	publisher := &AssuredPublisher{Publisher{connection: publisherConnection}}
+	publisher.construct()
+	return publisher
+}
+
+// NewAssuredPublisherWithConnection constructs a new AssuredPublisher instance
+func NewAssuredPublisherWithConnection(connection *Connection) *AssuredPublisher {
+	publisher := &AssuredPublisher{Publisher{connection: connection}}
+	publisher.construct()
 	return publisher
 }
 

--- a/assured_publisher.go
+++ b/assured_publisher.go
@@ -146,22 +146,17 @@ func (p *AssuredPublisher) receiveAllConfirmations() bool {
 	if len(p.unconfirmedMessages) == 0 {
 		return true
 	}
-	result := true
 	for {
 		select {
 		case confirmed := <-p._notifyPublish[0].channel:
 			if confirmed.Ack {
 				delete(p.unconfirmedMessages, confirmed.DeliveryTag)
 			} else {
-				nilConfirmation := amqp.Confirmation{}
-				if nilConfirmation == confirmed {
-					return result
-				}
 				log.Printf("Unknown Error (RabbitMQ Ack is false)")
-				result = false
+				return false
 			}
 		default:
-			return result
+			return true
 		}
 	}
 }

--- a/assured_publisher.go
+++ b/assured_publisher.go
@@ -7,59 +7,104 @@ import (
 	"github.com/streadway/amqp"
 )
 
+const unconfirmedMessagesMaxCount = 1000
+
 //AssuredPublisher allows you to publish events to RabbitMQ with implicit delivery confirmation
 type AssuredPublisher struct {
 	Publisher
+
+	unconfirmedMessages     map[uint64]*unconfirmedMessageSpec
+	sequenceNumber          uint64
+	waitAfterEachPublishing bool
+	closeChannel            chan *amqp.Error
+}
+
+type unconfirmedMessageSpec struct {
+	message    string
+	subscriber *Subscriber
 }
 
 func (p *AssuredPublisher) construct() {
-	p.NotifyPublish(make(chan amqp.Confirmation, 1))
+	p.initNewChannel()
+	p.NotifyPublish(unconfirmedMessagesMaxCount)
 	for err := p.Confirm(false); err != nil; err = p.Confirm(false) {
 		logError(err, "Can't setup confirmations for a publisher")
 		time.Sleep(1)
 	}
 }
 
+func (p *AssuredPublisher) initNewChannel() {
+	log.Print("Init new channel")
+	channel := p.GetChannel()
+	p.closeChannel = channel.NotifyClose(make(chan *amqp.Error, 1))
+	p.sequenceNumber = 0
+}
+
+func (p *AssuredPublisher) ensureChannel(cancel <-chan bool) {
+	p.GetChannel()
+	select {
+	case <-p.closeChannel:
+		p.reconnect(cancel)
+	default:
+	}
+}
+
+func (p *AssuredPublisher) reconnect(cancel <-chan bool) bool {
+	p.receiveAllConfirmations()
+	p.Close()
+	p.initNewChannel()
+	return p.republishAllMessages(cancel)
+}
+
+func (p *AssuredPublisher) republishAllMessages(cancel <-chan bool) bool {
+	messages := make([]*unconfirmedMessageSpec, 0, len(p.unconfirmedMessages))
+	for _, message := range p.unconfirmedMessages {
+		messages = append(messages, message)
+	}
+	p.unconfirmedMessages = map[uint64]*unconfirmedMessageSpec{}
+	for _, message := range messages {
+		if !p.Publish(message.message, message.subscriber, cancel) { // if cancelled
+			return false
+		}
+	}
+	return true
+}
+
 // NewAssuredPublisher constructs a new AssuredPublisher instance
 func NewAssuredPublisher() *AssuredPublisher {
-	publisher := &AssuredPublisher{Publisher{connection: publisherConnection}}
+	publisher := &AssuredPublisher{Publisher: Publisher{connection: publisherConnection}, unconfirmedMessages: map[uint64]*unconfirmedMessageSpec{}, waitAfterEachPublishing: true}
 	publisher.construct()
 	return publisher
 }
 
 // NewAssuredPublisherWithConnection constructs a new AssuredPublisher instance
 func NewAssuredPublisherWithConnection(connection *Connection) *AssuredPublisher {
-	publisher := &AssuredPublisher{Publisher{connection: connection}}
+	publisher := &AssuredPublisher{Publisher: Publisher{connection: connection}, unconfirmedMessages: map[uint64]*unconfirmedMessageSpec{}, waitAfterEachPublishing: true}
 	publisher.construct()
 	return publisher
+}
+
+// SetExplicitWaiting disables implicit waiting for a confirmation after each publishing
+func (p *AssuredPublisher) SetExplicitWaiting() {
+	p.waitAfterEachPublishing = false
 }
 
 // Publish pushes items on to a RabbitMQ Queue.
 // For AssuredPublisher it waits for delivery confirmaiton and retries on failures
 func (p *AssuredPublisher) Publish(message string, subscriber *Subscriber, cancel <-chan bool) bool {
-	for {
-		if err := (&p.Publisher).Publish(message, subscriber); err != nil {
-			log.Printf("Error on pushing into RabbitMQ: %v", err)
-			select {
-			case <-cancel:
-				return false
-			default:
-			}
-			continue
-		}
-		break
-	}
-	if !p.waitForConfirmation(cancel) {
-		p.Close()
-		return false
-	}
-	return true
+	return p.PublishBytes([]byte(message), subscriber, cancel)
 }
 
 // PublishBytes is the same as Publish but accepts a []byte instead of a string.
 // For AssuredPublisher it waits for delivery confirmaiton and retries on failures
 func (p *AssuredPublisher) PublishBytes(message []byte, subscriber *Subscriber, cancel <-chan bool) bool {
 	for {
+		p.ensureChannel(cancel)
+		if len(p.unconfirmedMessages) >= unconfirmedMessagesMaxCount {
+			if !p.waitForConfirmation(cancel) {
+				return false
+			}
+		}
 		if err := (&p.Publisher).PublishBytes(message, subscriber); err != nil {
 			log.Printf("Error on pushing into RabbitMQ: %v", err)
 			select {
@@ -71,8 +116,9 @@ func (p *AssuredPublisher) PublishBytes(message []byte, subscriber *Subscriber, 
 		}
 		break
 	}
-	if !p.waitForConfirmation(cancel) {
-		p.Close()
+	p.sequenceNumber++
+	p.unconfirmedMessages[p.sequenceNumber] = &unconfirmedMessageSpec{string(message), subscriber}
+	if p.waitAfterEachPublishing && !p.waitForConfirmation(cancel) {
 		return false
 	}
 	return true
@@ -81,16 +127,54 @@ func (p *AssuredPublisher) PublishBytes(message []byte, subscriber *Subscriber, 
 func (p *AssuredPublisher) waitForConfirmation(cancel <-chan bool) bool {
 	timeout := time.After(10 * time.Second)
 	select {
-	case confirmed := <-p._notifyPublish[0]:
+	case confirmed := <-p._notifyPublish[0].channel:
 		if confirmed.Ack {
+			delete(p.unconfirmedMessages, confirmed.DeliveryTag)
 			return true
 		}
 		log.Printf("Unknown Error (RabbitMQ Ack is false)")
-		return false
+		p.receiveAllConfirmations()
+		return p.reconnect(cancel)
 	case <-timeout:
 		log.Printf("Error: RabbitMQ Timeout")
-		return false
+		return p.reconnect(cancel)
 	case <-cancel:
 		return false
+	}
+}
+
+func (p *AssuredPublisher) receiveAllConfirmations() bool {
+	if len(p.unconfirmedMessages) == 0 {
+		return true
+	}
+	result := true
+	for {
+		select {
+		case confirmed := <-p._notifyPublish[0].channel:
+			if confirmed.Ack {
+				delete(p.unconfirmedMessages, confirmed.DeliveryTag)
+			} else {
+				nilConfirmation := amqp.Confirmation{}
+				if nilConfirmation == confirmed {
+					return result
+				}
+				log.Printf("Unknown Error (RabbitMQ Ack is false)")
+				result = false
+			}
+		default:
+			return result
+		}
+	}
+}
+
+// WaitForAllConfirmations waits for all confirmations and retries publishing if needed
+func (p *AssuredPublisher) WaitForAllConfirmations(cancel <-chan bool) bool {
+	for {
+		if len(p.unconfirmedMessages) == 0 {
+			return true
+		}
+		if !p.waitForConfirmation(cancel) {
+			return false
+		}
 	}
 }

--- a/assured_publisher.go
+++ b/assured_publisher.go
@@ -34,7 +34,6 @@ func (p *AssuredPublisher) construct() {
 }
 
 func (p *AssuredPublisher) initNewChannel() {
-	log.Print("Init new channel")
 	channel := p.GetChannel()
 	p.closeChannel = channel.NotifyClose(make(chan *amqp.Error, 1))
 	p.sequenceNumber = 0

--- a/assured_publisher_test.go
+++ b/assured_publisher_test.go
@@ -45,6 +45,8 @@ func TestPublishWithExplicitWaiting(t *testing.T) {
 
 	publisher := rabbit.NewAssuredPublisher()
 	publisher.SetExplicitWaiting()
+	err := rabbit.CreateQueue(publisher.GetChannel(), &subscriber)
+	assert.Nil(err)
 
 	publisher.GetChannel().QueueDelete(subscriber.Queue, true, false, false)
 

--- a/assured_publisher_test.go
+++ b/assured_publisher_test.go
@@ -25,6 +25,8 @@ func TestPublishAssured(t *testing.T) {
 
 	message := "Test Message"
 	publisher := rabbit.NewAssuredPublisher()
+	err := rabbit.CreateQueue(publisher.GetChannel(), &subscriber)
+	assert.Nil(err)
 	ok := publisher.Publish(message, &subscriber, make(chan bool))
 
 	var result string

--- a/assured_publisher_test.go
+++ b/assured_publisher_test.go
@@ -3,6 +3,12 @@ package rabbit_test
 import (
 	"testing"
 
+	"time"
+
+	"fmt"
+
+	"sync"
+
 	"github.com/brettallred/go-rabbit"
 	"github.com/stretchr/testify/assert"
 )
@@ -11,9 +17,9 @@ func TestPublishAssured(t *testing.T) {
 	var subscriber = rabbit.Subscriber{
 		Concurrency: 5,
 		Durable:     true,
-		Exchange:    "events",
-		Queue:       "test.publishsample.event.created",
-		RoutingKey:  "publishsample.event.created",
+		Exchange:    "events_test",
+		Queue:       "test.assuredpublishsample.event.created",
+		RoutingKey:  "assuredpublishsample.event.created",
 	}
 	assert := assert.New(t)
 
@@ -25,4 +31,70 @@ func TestPublishAssured(t *testing.T) {
 	result, _ = rabbit.Pop(&subscriber)
 	assert.Equal(message, result)
 	assert.True(ok)
+}
+
+func TestPublishWithExplicitWaiting(t *testing.T) {
+	var subscriber = rabbit.Subscriber{
+		Concurrency: 5,
+		Durable:     true,
+		Exchange:    "events_test",
+		Queue:       "test.assuredpublishsampleexpl.event.created",
+		RoutingKey:  "publishsampleexp.event.created",
+	}
+	assert := assert.New(t)
+
+	publisher := rabbit.NewAssuredPublisher()
+	publisher.SetExplicitWaiting()
+
+	publisher.GetChannel().QueueDelete(subscriber.Queue, true, false, false)
+
+	messagesMap := map[string]bool{}
+	doneReading := make(chan bool)
+	messagesRead := 0
+	lock := sync.Mutex{}
+
+	subscriberHandler := func(payload []byte) bool {
+		lock.Lock()
+		defer lock.Unlock()
+		messagesMap[string(payload)] = true
+		messagesRead++
+		if len(messagesMap) == 10000 {
+			close(doneReading)
+		}
+		return true
+	}
+	rabbit.Register(subscriber, subscriberHandler)
+	rabbit.StartSubscribers()
+	defer rabbit.CloseSubscribers()
+
+	for i := 0; i < 10000; i++ {
+		if i != 0 && i%999 == 0 {
+			// kill the connection
+			publisher.GetChannel().ExchangeDelete(subscriber.Exchange, true, true)
+			publisher.GetChannel().ExchangeDeclare(subscriber.Exchange, "topic", false, false, false, false, nil)
+		}
+		ok := publisher.Publish(fmt.Sprintf("%d", i), &subscriber, make(chan bool))
+		assert.True(ok)
+	}
+	done := make(chan bool)
+	cancel := make(chan bool)
+	go func() {
+		result := publisher.WaitForAllConfirmations(cancel)
+		assert.True(result)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		close(cancel)
+		assert.Fail("Timeout while waiting for confirmations")
+	}
+
+	select {
+	case <-doneReading:
+	case <-time.After(10 * time.Second):
+		close(cancel)
+		assert.Fail(fmt.Sprintf("Timeout while reading messages. Messages read: %d", messagesRead))
+	}
+	assert.Len(messagesMap, 10000)
 }

--- a/assured_publisher_test.go
+++ b/assured_publisher_test.go
@@ -1,13 +1,10 @@
 package rabbit_test
 
 import (
-	"testing"
-
-	"time"
-
 	"fmt"
-
 	"sync"
+	"testing"
+	"time"
 
 	"github.com/brettallred/go-rabbit"
 	"github.com/stretchr/testify/assert"

--- a/channel.go
+++ b/channel.go
@@ -24,7 +24,9 @@ func closeConnectionOnChannelNotifyClose(errorChannel chan *amqp.Error) {
 	case <-errorChannel:
 		lock.Lock()
 		defer lock.Unlock()
-		_connection.Close()
+		if _connection != nil {
+			_connection.Close()
+		}
 		return
 	}
 }

--- a/channel.go
+++ b/channel.go
@@ -1,8 +1,6 @@
 package rabbit
 
-import (
-	"github.com/streadway/amqp"
-)
+import "github.com/streadway/amqp"
 
 func createConnectionClosingChannel(conn *amqp.Connection) (*amqp.Channel, error) {
 	channel, err := conn.Channel()
@@ -11,22 +9,5 @@ func createConnectionClosingChannel(conn *amqp.Connection) (*amqp.Channel, error
 		return channel, err
 	}
 
-	errorChannel := make(chan *amqp.Error, 1)
-	channel.NotifyClose(errorChannel)
-
-	go closeConnectionOnChannelNotifyClose(errorChannel)
-
 	return channel, nil
-}
-
-func closeConnectionOnChannelNotifyClose(errorChannel chan *amqp.Error) {
-	select {
-	case <-errorChannel:
-		lock.Lock()
-		defer lock.Unlock()
-		if _connection != nil {
-			_connection.Close()
-		}
-		return
-	}
 }

--- a/channel.go
+++ b/channel.go
@@ -24,7 +24,6 @@ func closeConnectionOnChannelNotifyClose(errorChannel chan *amqp.Error, conn *am
 		defer lock.Unlock()
 		if _connection == conn {
 			_connection.Close()
-			_connection = nil
 		}
 		return
 	}

--- a/channel.go
+++ b/channel.go
@@ -1,6 +1,8 @@
 package rabbit
 
-import "github.com/streadway/amqp"
+import (
+	"github.com/streadway/amqp"
+)
 
 func createConnectionClosingChannel(conn *amqp.Connection) (*amqp.Channel, error) {
 	channel, err := conn.Channel()
@@ -9,5 +11,22 @@ func createConnectionClosingChannel(conn *amqp.Connection) (*amqp.Channel, error
 		return channel, err
 	}
 
+	errorChannel := make(chan *amqp.Error, 1)
+	channel.NotifyClose(errorChannel)
+
+	go closeConnectionOnChannelNotifyClose(errorChannel)
+
 	return channel, nil
+}
+
+func closeConnectionOnChannelNotifyClose(errorChannel chan *amqp.Error) {
+	select {
+	case <-errorChannel:
+		lock.Lock()
+		defer lock.Unlock()
+		if _connection != nil {
+			_connection.Close()
+		}
+		return
+	}
 }

--- a/connection.go
+++ b/connection.go
@@ -36,9 +36,11 @@ func handleConnectionError(myConnection *amqp.Connection, e *amqp.Error) {
 		connectionWithoutLock()
 		if _connection != nil && subscribersStarted {
 			err := startSubscribers(_connection)
+			c := _connection
 			lock.Unlock()
 			if err != nil {
 				log.Printf("Error on subscribing to RabbitMQ: %s", err.Error())
+				defer c.Close()
 			}
 		} else {
 			lock.Unlock()

--- a/connection.go
+++ b/connection.go
@@ -36,11 +36,9 @@ func handleConnectionError(myConnection *amqp.Connection, e *amqp.Error) {
 		connectionWithoutLock()
 		if _connection != nil && subscribersStarted {
 			err := startSubscribers(_connection)
-			c := _connection
 			lock.Unlock()
 			if err != nil {
 				log.Printf("Error on subscribing to RabbitMQ: %s", err.Error())
-				defer c.Close()
 			}
 		} else {
 			lock.Unlock()

--- a/connection.go
+++ b/connection.go
@@ -74,8 +74,14 @@ func connect() *amqp.Connection {
 
 // Connection represents an autorecovering connection
 type Connection struct {
+	url        string
 	connection *amqp.Connection
 	lock       sync.RWMutex
+}
+
+// NewConnectionWithURL creates a new connection with a custom RabbitMQ URL
+func NewConnectionWithURL(url string) *Connection {
+	return &Connection{url: url}
 }
 
 // Close closes a connection
@@ -116,9 +122,13 @@ func (connection *Connection) connect() {
 	connection.connection = nil
 	var c *amqp.Connection
 	var err error
+	url := connection.url
+	if url == "" {
+		url = os.Getenv("RABBITMQ_URL")
+	}
 	for {
-		log.Printf("Creating a new RabbitMQ connection for publisher")
-		c, err = amqp.Dial(os.Getenv("RABBITMQ_URL"))
+		log.Printf("Creating a new RabbitMQ connection for publisher (%s)", url)
+		c, err = amqp.Dial(url)
 		if err != nil {
 			connection.connection = nil
 			logError(err, "Failed to connect to RabbitMQ")

--- a/connection.go
+++ b/connection.go
@@ -23,11 +23,12 @@ func connectionWithoutLock() *amqp.Connection {
 }
 
 func handleConnectionError(myConnection *amqp.Connection, e *amqp.Error) {
-	if e == nil {
+	lock.Lock()
+	if e == nil && _connection == nil { // the connection has been intentionally closed
+		lock.Unlock()
 		return
 	}
 	log.Printf("RabbitMQ connection failed, we will redial: %+#v", e)
-	lock.Lock()
 	if myConnection == _connection {
 		_connection = nil
 	}

--- a/pop.go
+++ b/pop.go
@@ -2,21 +2,22 @@ package rabbit
 
 import (
 	"errors"
-	"github.com/streadway/amqp"
 	"log"
+
+	"github.com/streadway/amqp"
 )
 
-var popConnection *amqp.Connection
+var popConnection *Connection
 var popChannel *amqp.Channel
 
 // InitPop intializes the RabbitMQ Connection and Channel for popping messages off of a queue.
 func InitPop() {
 	if popConnection == nil {
-		popConnection = connect()
+		popConnection = &Connection{}
 	}
 
 	if popChannel == nil {
-		popChannel, _ = popConnection.Channel()
+		popChannel, _ = popConnection.GetConnection().Channel()
 	}
 }
 
@@ -45,4 +46,13 @@ func Pop(subscriber *Subscriber) (string, error) {
 		return string(message.Body), nil
 	}
 	return "", err
+}
+
+// ResetPopConnection sets popConnection=nil and popChannel=nil for testing purposes
+func ResetPopConnection() {
+	if popConnection != nil {
+		popConnection.Close()
+	}
+	popConnection = nil
+	popChannel = nil
 }

--- a/pop_test.go
+++ b/pop_test.go
@@ -11,17 +11,19 @@ func TestPop(t *testing.T) {
 	var subscriber = rabbit.Subscriber{
 		Concurrency: 5,
 		Durable:     true,
-		Exchange:    "events",
+		Exchange:    "events_test",
 		Queue:       "poptest.popsample.event.created",
 		RoutingKey:  "popsample.event.created",
 	}
+	recreateQueue(t, &subscriber)
 
 	assert := assert.New(t)
 
 	message := "Test Message"
 	rabbit.NewPublisher().Publish(message, &subscriber)
 
-	var result string
-	result, _ = rabbit.Pop(&subscriber)
+	rabbit.ResetPopConnection()
+	result, err := rabbit.Pop(&subscriber)
+	assert.Nil(err)
 	assert.Equal(message, result)
 }

--- a/publisher.go
+++ b/publisher.go
@@ -2,10 +2,9 @@ package rabbit
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"time"
-
-	"fmt"
 
 	"github.com/streadway/amqp"
 )

--- a/publisher.go
+++ b/publisher.go
@@ -2,15 +2,19 @@ package rabbit
 
 import (
 	"errors"
-	"github.com/streadway/amqp"
 	"log"
 	"time"
+
+	"github.com/streadway/amqp"
 )
 
-var publisherConnection = &Connection{}
+var (
+	publisherConnection = &Connection{}
+)
 
 //Publisher allows you to publish events to RabbitMQ
 type Publisher struct {
+	connection        *Connection
 	_channel          *amqp.Channel
 	_notifyPublish    []chan amqp.Confirmation
 	_reliableMode     bool
@@ -19,7 +23,12 @@ type Publisher struct {
 
 // NewPublisher constructs a new Publisher instance.
 func NewPublisher() *Publisher {
-	return &Publisher{}
+	return &Publisher{connection: publisherConnection}
+}
+
+// NewPublisherWithConnection constructs a new Publisher instance with a custom connection
+func NewPublisherWithConnection(connection *Connection) *Publisher {
+	return &Publisher{connection: connection}
 }
 
 // GetChannel returns a publisher's channel. It opens a new channel if needed.
@@ -39,7 +48,7 @@ func (p *Publisher) GetChannel() *amqp.Channel {
 }
 
 func (p *Publisher) openChannel() (err error) {
-	c := publisherConnection.GetConnection()
+	c := p.connection.GetConnection()
 	p._channel, err = c.Channel()
 
 	if err != nil {

--- a/publisher.go
+++ b/publisher.go
@@ -130,9 +130,7 @@ func (p *Publisher) Close() {
 	}
 	if p.connection != nil {
 		p.connection.Close()
-	} else {
-		if publisherConnection != nil {
-			publisherConnection.Close()
-		}
+	} else if publisherConnection != nil {
+		publisherConnection.Close()
 	}
 }

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/brettallred/go-rabbit"
-	"github.com/streadway/amqp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,12 +11,13 @@ func TestPublish(t *testing.T) {
 	var subscriber = rabbit.Subscriber{
 		Concurrency: 5,
 		Durable:     true,
-		Exchange:    "events",
+		Exchange:    "events_test",
 		Queue:       "test.publishsample.event.created",
 		RoutingKey:  "publishsample.event.created",
 	}
 	assert := assert.New(t)
 
+	recreateQueue(t, &subscriber)
 	message := "Test Message"
 	publisher := rabbit.NewPublisher()
 	publisher.Publish(message, &subscriber)
@@ -31,13 +31,18 @@ func TestConfirm(t *testing.T) {
 	var subscriber = rabbit.Subscriber{
 		Concurrency: 5,
 		Durable:     true,
-		Exchange:    "events",
+		Exchange:    "events_test",
 		Queue:       "test.confirmsample.event.created",
 		RoutingKey:  "confirmsample.event.created",
 	}
 	publisher := rabbit.NewPublisher()
-	confirms := publisher.NotifyPublish(make(chan amqp.Confirmation, 1))
+	confirms := publisher.NotifyPublish(1)
 	publisher.Confirm(false)
+	publisher.Publish("something", &subscriber)
+	rabbit.Pop(&subscriber)
+	<-confirms
+
+	publisher.Close()
 	publisher.Publish("something", &subscriber)
 	rabbit.Pop(&subscriber)
 	<-confirms

--- a/queue.go
+++ b/queue.go
@@ -35,3 +35,17 @@ func deleteQueue(channel *amqp.Channel, subscriber *Subscriber) error {
 	_, err := channel.QueueDelete(subscriber.Queue, false, false, false)
 	return err
 }
+
+// CreateQueue creates a queue and binds it
+func CreateQueue(channel *amqp.Channel, subscriber *Subscriber) error {
+	if err := createExchange(channel, subscriber); err != nil {
+		return err
+	}
+	if err := createQueue(channel, subscriber); err != nil {
+		return err
+	}
+	if err := bindQueue(channel, subscriber); err != nil {
+		return err
+	}
+	return nil
+}

--- a/rabbit_test.go
+++ b/rabbit_test.go
@@ -48,6 +48,7 @@ func TestRegister(t *testing.T) {
 }
 
 func TestNack(t *testing.T) {
+	recreateQueue(t, &subscriber)
 	counter := 0
 	done := make(chan bool, 2)
 	nackHandler := func(payload []byte) bool {

--- a/rabbit_test.go
+++ b/rabbit_test.go
@@ -30,14 +30,13 @@ func sampleTestEventCreatedHandler(payload []byte) bool {
 var subscriber = rabbit.Subscriber{
 	Concurrency: 5,
 	Durable:     true,
-	Exchange:    "events",
+	Exchange:    "events_test",
 	Queue:       "test.sample.event.created",
 	RoutingKey:  "sample.event.created",
 }
 
-func TestMain(m *testing.M) {
+func init() {
 	os.Setenv("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
-	os.Exit(m.Run())
 }
 
 func TestRegister(t *testing.T) {
@@ -77,4 +76,47 @@ func TestNack(t *testing.T) {
 func TestStartingSubscribers(t *testing.T) {
 	rabbit.Register(subscriber, sampleTestEventCreatedHandler)
 	rabbit.StartSubscribers()
+}
+
+func recreateQueue(t *testing.T, subscriber *rabbit.Subscriber) {
+	done := make(chan bool)
+	publisher := rabbit.NewPublisher()
+	go func() {
+		for {
+			if _, err := publisher.GetChannel().QueueDelete(subscriber.Queue, false, false, true); err == nil {
+				close(done)
+				return
+			} else {
+				log.Printf("Error on removing queue: %+#v", err)
+				publisher.Close()
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Error("Can't delete queue")
+		t.Fail()
+		return
+	}
+
+	done = make(chan bool)
+	go func() {
+		for {
+			if err := rabbit.CreateQueue(publisher.GetChannel(), subscriber); err == nil {
+				close(done)
+				return
+			} else {
+				log.Printf("Error on creating queue: %+#v", err)
+				publisher.Close()
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Error("Can't create queue")
+		t.Fail()
+		return
+	}
 }

--- a/subscriber.go
+++ b/subscriber.go
@@ -104,7 +104,7 @@ func CloseSubscribers() {
 	if _connection != nil {
 		c := _connection
 		_connection = nil
-		go c.Close()
+		c.Close()
 	}
 }
 

--- a/subscriber.go
+++ b/subscriber.go
@@ -68,13 +68,7 @@ func startSubscribers(conn *amqp.Connection) error {
 			if err != nil {
 				return err
 			}
-			if err := createExchange(channel, &subscriber); err != nil {
-				return err
-			}
-			if err := createQueue(channel, &subscriber); err != nil {
-				return err
-			}
-			if err := bindQueue(channel, &subscriber); err != nil {
+			if err := CreateQueue(channel, &subscriber); err != nil {
 				return err
 			}
 			if err := createConsumer(channel, &subscriber); err != nil {

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -69,7 +69,10 @@ func TestSubscribersReconnection(t *testing.T) {
 	rabbit.CloseSubscribers()
 	done := make(chan bool, 100)
 	handler := func(payload []byte) bool {
-		done <- true
+		go func() {
+			time.Sleep(1)
+			done <- true
+		}()
 		return true
 	}
 	rabbit.Register(subscriber, handler)
@@ -84,7 +87,7 @@ func TestSubscribersReconnection(t *testing.T) {
 		t.Error("Timeout on waiting for subscriber")
 		t.Fail()
 	}
-	publisher.GetChannel().QueueDelete(subscriber.Queue, false, false, false) // reconnect
+	publisher.GetChannel().QueueDelete(subscriber.Queue, false, false, true) // reconnect
 	recreateQueue(t, &subscriber)
 	time.Sleep(5 * time.Second)
 	timeoutChannel := time.After(5 * time.Second)

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -88,9 +88,7 @@ func TestSubscribersReconnection(t *testing.T) {
 		t.Fail()
 	}
 	publisher.GetChannel().QueueDelete(subscriber.Queue, false, false, true) // reconnect
-	time.Sleep(2 * time.Second)
 	recreateQueue(t, &subscriber)
-	time.Sleep(2 * time.Second)
 	timeoutChannel := time.After(5 * time.Second)
 	publisher = rabbit.NewPublisher()
 	for {

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -86,7 +86,8 @@ func TestSubscribersReconnection(t *testing.T) {
 	}
 	publisher.GetChannel().QueueDelete(subscriber.Queue, false, false, false) // reconnect
 	recreateQueue(t, &subscriber)
-	timeoutChannel := time.After(15 * time.Second)
+	time.Sleep(5 * time.Second)
+	timeoutChannel := time.After(5 * time.Second)
 	publisher = rabbit.NewPublisher()
 	for {
 		select {

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -64,6 +64,7 @@ func TestSubscribersReconnection(t *testing.T) {
 		RoutingKey:  "sample.event.created",
 	}
 	rabbit.CloseSubscribers()
+	rabbit.CreateQueue(rabbit.NewPublisher().GetChannel(), &subscriber)
 	recreateQueue(t, &subscriber)
 	rabbit.CloseSubscribers()
 	done := make(chan bool, 100)

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -88,7 +88,9 @@ func TestSubscribersReconnection(t *testing.T) {
 		t.Fail()
 	}
 	publisher.GetChannel().QueueDelete(subscriber.Queue, false, false, true) // reconnect
+	time.Sleep(2 * time.Second)
 	recreateQueue(t, &subscriber)
+	time.Sleep(2 * time.Second)
 	timeoutChannel := time.After(5 * time.Second)
 	publisher = rabbit.NewPublisher()
 	for {

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -88,9 +88,6 @@ func TestSubscribersReconnection(t *testing.T) {
 		t.Fail()
 	}
 	publisher.GetChannel().QueueDelete(subscriber.Queue, false, false, true) // reconnect
-	time.Sleep(2 * time.Second)
-	recreateQueue(t, &subscriber)
-	time.Sleep(2 * time.Second)
 	timeoutChannel := time.After(5 * time.Second)
 	publisher = rabbit.NewPublisher()
 	for {

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -88,8 +88,9 @@ func TestSubscribersReconnection(t *testing.T) {
 		t.Fail()
 	}
 	publisher.GetChannel().QueueDelete(subscriber.Queue, false, false, true) // reconnect
+	time.Sleep(2 * time.Second)
 	recreateQueue(t, &subscriber)
-	time.Sleep(5 * time.Second)
+	time.Sleep(2 * time.Second)
 	timeoutChannel := time.After(5 * time.Second)
 	publisher = rabbit.NewPublisher()
 	for {

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -6,6 +6,10 @@ import (
 	"os/user"
 	"testing"
 
+	"time"
+
+	"log"
+
 	"github.com/brettallred/go-rabbit"
 	"github.com/stretchr/testify/assert"
 )
@@ -52,4 +56,50 @@ func TestIsDevelopmentEnv(t *testing.T) {
 	os.Setenv("APP_ENV", "staging")
 	assert.False(t, rabbit.IsDevelopmentEnv())
 
+}
+
+func TestSubscribersReconnection(t *testing.T) {
+	var subscriber = rabbit.Subscriber{
+		Concurrency: 5,
+		Durable:     true,
+		Exchange:    "events_test",
+		Queue:       "test.sample.event.created",
+		RoutingKey:  "sample.event.created",
+	}
+	rabbit.CloseSubscribers()
+	recreateQueue(t, &subscriber)
+	done := make(chan bool, 100)
+	handler := func(payload []byte) bool {
+		done <- true
+		return true
+	}
+	rabbit.Register(subscriber, handler)
+	rabbit.StartSubscribers()
+	connection := rabbit.NewConnectionWithURL(os.Getenv("RABBITMQ_URL"))
+	connection.ReplaceConnection(rabbit.ExposeSubscriberConnectionForTests())
+	publisher := rabbit.NewPublisherWithConnection(connection)
+	publisher.Publish("test", &subscriber)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Error("Timeout on waiting for subscriber")
+		t.Fail()
+	}
+	publisher.GetChannel().QueueDelete(subscriber.Queue, false, false, false) // reconnect
+	timeoutChannel := time.After(5 * time.Second)
+	publisher = rabbit.NewPublisher()
+	for {
+		select {
+		case <-done:
+			return
+		case <-timeoutChannel:
+			log.Printf("timeout")
+			t.Error("Timeout on waiting for subscriber")
+			t.Fail()
+			return
+		default:
+			publisher.Publish("test", &subscriber)
+			time.Sleep(1 * time.Second)
+		}
+	}
 }

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -70,7 +70,7 @@ func TestSubscribersReconnection(t *testing.T) {
 	done := make(chan bool, 100)
 	handler := func(payload []byte) bool {
 		go func() {
-			time.Sleep(1)
+			time.Sleep(1 * time.Second)
 			done <- true
 		}()
 		return true

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/user"
 	"testing"
-
 	"time"
 
 	"github.com/brettallred/go-rabbit"

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -87,7 +87,7 @@ func TestSubscribersReconnection(t *testing.T) {
 		t.Error("Timeout on waiting for subscriber")
 		t.Fail()
 	}
-	publisher.GetChannel().QueueDelete(subscriber.Queue, false, false, true) // reconnect
+	publisher.Close() // the subscriber should reconnect
 	timeoutChannel := time.After(5 * time.Second)
 	publisher = rabbit.NewPublisher()
 	for {


### PR DESCRIPTION
* allow publishing to RabbitMQ servers different from the one specified in RABBITMQ_URL
* prevent a crash on connection closing
* rework AssuredPublisher to introduce batch confirmations and retry on getting negative acknowledgements or errors
* eliminate a deadlock upon reconnection of the subscriber
* recreate publishers' confirmations channels upon reconnecting
* add tests for reconnections & AssuredPublisher
* fix found bugs