### PR TITLE
Improve publishers

### DIFF
--- a/assured_publisher.go
+++ b/assured_publisher.go
@@ -32,188 +32,247 @@ func (p *AssuredPublisher) construct() {
 	p.NotifyPublish(unconfirmedMessagesMaxCount)
 	for err := p.Confirm(false); err != nil; err = p.Confirm(false) {
 		logError(err, "Can't setup confirmations for a publisher")
-		time.Sleep(1)
+		select {
+		case <-p.cancelChannel:
+			return
+		case <-time.After(1 * time.Second):
+		}
 	}
 }
 
+// should be within locked block
 func (p *AssuredPublisher) initNewChannel() {
-	channel := p.GetChannel()
-	p.closeChannel = channel.NotifyClose(make(chan *amqp.Error, 1))
+	channel := p.getChannelWithoutLock()
+	closeChannel := channel.NotifyClose(make(chan *amqp.Error, 1))
+	p.lock.Lock()
+	p.closeChannel = closeChannel
 	p.sequenceNumber = 0
+	p.lock.Unlock()
 	go p.continuoslyReceiveConfirmations()
 }
 
-func (p *AssuredPublisher) ensureChannel(cancel <-chan bool) {
-	p.GetChannel()
+// should be within locked block
+func (p *AssuredPublisher) ensureChannel() {
+	p.getChannelWithoutLock()
+	p.lock.Lock()
+	closeChannel := p.closeChannel
+	p.lock.Unlock()
 	select {
-	case <-p.closeChannel:
-		p.reconnect(cancel)
+	case e := <-closeChannel:
+		log.Printf("Error: publisher's channel has been closed (%+#v). Recreating it", e)
+		p.lock.Lock()
+		p._channel = nil
+		p.lock.Unlock()
+		p.reconnect()
 	default:
 	}
 }
 
-func (p *AssuredPublisher) reconnect(cancel <-chan bool) bool {
+// should be within locked block
+func (p *AssuredPublisher) reconnect() bool {
 	p.receiveAllConfirmations()
-	p.Close()
 	p.initNewChannel()
-	return p.republishAllMessages(cancel)
+	return p.republishAllMessages()
 }
 
-func (p *AssuredPublisher) republishAllMessages(cancel <-chan bool) bool {
+func (p *AssuredPublisher) republishAllMessages() bool {
 	messages := map[uint64]*unconfirmedMessage{}
+	p.lock.Lock()
 	for deliveryTag, message := range p.unconfirmedMessages {
 		messages[deliveryTag] = message
 	}
-	p.unconfirmedMessages = map[uint64]*unconfirmedMessage{}
+	p.unconfirmedMessages = map[uint64]*unconfirmedMessage{0: &unconfirmedMessage{}}
+	doNotRepublish := p.doNotRepublish
+	confirmationHandler := p.confirmationHandler
+	p.lock.Unlock()
 	for deliveryTag, message := range messages {
-		if !p.doNotRepublish {
-			if !p.publishBytesWithArgWithoutLock(message.message, message.subscriber, message.arg, cancel) { // if cancelled
+		if deliveryTag == 0 {
+			continue
+		}
+		if !doNotRepublish {
+			if !p.publishBytesWithArgWithoutLock(message.message, message.subscriber, message.arg) { // if cancelled
 				return false
 			}
 		} else {
-			if p.confirmationHandler != nil {
-				p.confirmationHandler(amqp.Confirmation{Ack: false, DeliveryTag: deliveryTag}, message.arg)
+			if confirmationHandler != nil {
+				confirmationHandler(amqp.Confirmation{Ack: false, DeliveryTag: deliveryTag}, message.arg)
 			}
 		}
 	}
+	p.lock.Lock()
+	delete(p.unconfirmedMessages, 0)
+	p.lock.Unlock()
 	return true
 }
 
 // NewAssuredPublisher constructs a new AssuredPublisher instance
-func NewAssuredPublisher() *AssuredPublisher {
-	publisher := &AssuredPublisher{Publisher: Publisher{connection: publisherConnection}, unconfirmedMessages: map[uint64]*unconfirmedMessage{}, waitAfterEachPublishing: true}
+func NewAssuredPublisher(cancelChannel <-chan bool) *AssuredPublisher {
+	publisher := &AssuredPublisher{Publisher: Publisher{connection: publisherConnection, cancelChannel: cancelChannel},
+		unconfirmedMessages: map[uint64]*unconfirmedMessage{}, waitAfterEachPublishing: true}
 	publisher.construct()
 	return publisher
 }
 
 // NewAssuredPublisherWithConnection constructs a new AssuredPublisher instance
-func NewAssuredPublisherWithConnection(connection *Connection) *AssuredPublisher {
-	publisher := &AssuredPublisher{Publisher: Publisher{connection: connection}, unconfirmedMessages: map[uint64]*unconfirmedMessage{}, waitAfterEachPublishing: true}
+func NewAssuredPublisherWithConnection(connection *Connection, cancelChannel <-chan bool) *AssuredPublisher {
+	publisher := &AssuredPublisher{Publisher: Publisher{connection: connection, cancelChannel: cancelChannel},
+		unconfirmedMessages: map[uint64]*unconfirmedMessage{}, waitAfterEachPublishing: true}
 	publisher.construct()
 	return publisher
 }
 
 // SetExplicitWaiting disables implicit waiting for a confirmation after each publishing
 func (p *AssuredPublisher) SetExplicitWaiting() {
+	p.publicMethodsLock.Lock()
+	defer p.publicMethodsLock.Unlock()
+	p.lock.Lock()
 	p.waitAfterEachPublishing = false
+	p.lock.Unlock()
 }
 
 // DisableRepublishing disables messages republishing
 func (p *AssuredPublisher) DisableRepublishing() {
+	p.publicMethodsLock.Lock()
+	defer p.publicMethodsLock.Unlock()
+	p.lock.Lock()
 	p.doNotRepublish = true
+	p.lock.Unlock()
 }
 
 // SetConfirmationHandler sets the handler which is called for every confirmation received
 func (p *AssuredPublisher) SetConfirmationHandler(confirmationHandler func(amqp.Confirmation, interface{})) {
+	p.publicMethodsLock.Lock()
+	defer p.publicMethodsLock.Unlock()
+	p.lock.Lock()
 	p.confirmationHandler = confirmationHandler
+	p.lock.Unlock()
 }
 
 // Publish pushes items on to a RabbitMQ Queue.
 // For AssuredPublisher it waits for delivery confirmaiton and retries on failures
-func (p *AssuredPublisher) Publish(message string, subscriber *Subscriber, cancel <-chan bool) bool {
-	return p.PublishBytes([]byte(message), subscriber, cancel)
+func (p *AssuredPublisher) Publish(message string, subscriber *Subscriber) bool {
+	return p.PublishBytes([]byte(message), subscriber)
 }
 
 // PublishWithArg pushes items on to a RabbitMQ Queue. The argument will be stored for passing into the confirmation handler.
 // For AssuredPublisher it waits for delivery confirmaiton and retries on failures
-func (p *AssuredPublisher) PublishWithArg(message string, subscriber *Subscriber, arg interface{}, cancel <-chan bool) bool {
-	return p.PublishBytesWithArg([]byte(message), subscriber, arg, cancel)
+func (p *AssuredPublisher) PublishWithArg(message string, subscriber *Subscriber, arg interface{}) bool {
+	return p.PublishBytesWithArg([]byte(message), subscriber, arg)
 }
 
 // PublishBytes is the same as Publish but accepts a []byte instead of a string.
 // For AssuredPublisher it waits for delivery confirmaiton and retries on failures
-func (p *AssuredPublisher) PublishBytes(message []byte, subscriber *Subscriber, cancel <-chan bool) bool {
-	return p.PublishBytesWithArg(message, subscriber, nil, cancel)
+func (p *AssuredPublisher) PublishBytes(message []byte, subscriber *Subscriber) bool {
+	return p.PublishBytesWithArg(message, subscriber, nil)
 }
 
 // PublishBytesWithArg is the same as Publish but accepts a []byte instead of a string.
 // The argument will be stored for passing into the confirmation handler.
 // For AssuredPublisher it waits for delivery confirmaiton and retries on failures
-func (p *AssuredPublisher) PublishBytesWithArg(message []byte, subscriber *Subscriber, arg interface{}, cancel <-chan bool) bool {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-	return p.publishBytesWithArgWithoutLock(message, subscriber, arg, cancel)
+func (p *AssuredPublisher) PublishBytesWithArg(message []byte, subscriber *Subscriber, arg interface{}) bool {
+	p.publicMethodsLock.Lock()
+	defer p.publicMethodsLock.Unlock()
+	return p.publishBytesWithArgWithoutLock(message, subscriber, arg)
 }
 
-func (p *AssuredPublisher) publishBytesWithArgWithoutLock(message []byte, subscriber *Subscriber, arg interface{}, cancel <-chan bool) bool {
+func (p *AssuredPublisher) publishBytesWithArgWithoutLock(message []byte, subscriber *Subscriber, arg interface{}) bool {
 	for {
-		p.ensureChannel(cancel)
+		p.ensureChannel()
 		p.receiveAllConfirmations()
-		if len(p.unconfirmedMessages) >= unconfirmedMessagesMaxCount {
-			if !p.waitForConfirmation(cancel) {
+		p.lock.Lock()
+		unconfirmedCount := len(p.unconfirmedMessages)
+		p.lock.Unlock()
+		if unconfirmedCount >= unconfirmedMessagesMaxCount {
+			if !p.waitForConfirmation() {
 				return false
 			}
 		}
 		if err := (&p.Publisher).publishBytesWithoutLock(message, subscriber); err != nil {
 			log.Printf("Error on pushing into RabbitMQ: %v", err)
 			select {
-			case <-cancel:
+			case <-p.cancelChannel:
 				return false
-			default:
+			case <-time.After(1 * time.Second):
 			}
 			continue
 		}
 		break
 	}
+	p.lock.Lock()
 	p.sequenceNumber++
 	var body []byte
 	if !p.doNotRepublish {
 		body = message
 	}
 	p.unconfirmedMessages[p.sequenceNumber] = &unconfirmedMessage{body, subscriber, arg}
-	if p.waitAfterEachPublishing && !p.waitForConfirmation(cancel) {
+	p.lock.Unlock()
+	if p.waitAfterEachPublishing && !p.waitForConfirmation() {
 		return false
 	}
 	return true
 }
 
-func (p *AssuredPublisher) waitForConfirmation(cancel <-chan bool) bool {
-	timeout := time.After(10 * time.Second)
+func (p *AssuredPublisher) waitForConfirmation() bool {
 	for {
+		p.lock.Lock()
+		ch := p._notifyPublish[0].channel
+		p.lock.Unlock()
 		select {
-		case confirm := <-p._notifyPublish[0].channel:
+		case confirm := <-ch:
 			if !p.handleConfirmationMessage(confirm) {
-				if !p.reconnect(cancel) {
-					return false
-				}
+				p.lock.Lock()
 				if len(p.unconfirmedMessages) == 0 {
+					p.lock.Unlock()
 					return true
 				}
+				p.lock.Unlock()
 			} else {
 				return true
 			}
-		case <-timeout:
+		case <-time.After(10 * time.Second):
 			log.Printf("Error: RabbitMQ Timeout")
-			return p.reconnect(cancel)
-		case <-cancel:
+		case <-p.cancelChannel:
 			return false
 		}
+		log.Printf("Next in waitForConfirmation")
 	}
 }
 
 // ReceiveAllConfirmations explicitly receives all awaiting confirmations
 func (p *AssuredPublisher) ReceiveAllConfirmations() bool {
-	p.lock.Lock()
-	defer p.lock.Unlock()
+	p.publicMethodsLock.Lock()
+	defer p.publicMethodsLock.Unlock()
 	return p.receiveAllConfirmations()
 }
 
 func (p *AssuredPublisher) continuoslyReceiveConfirmations() {
 	for {
-		if !p.ReceiveAllConfirmations() {
+		if !p.receiveAllConfirmations() {
 			return
 		}
-		time.Sleep(1 * time.Second)
+		select {
+		case <-p.cancelChannel:
+			return
+		case <-time.After(1 * time.Second):
+		}
 	}
 }
 
 func (p *AssuredPublisher) receiveAllConfirmations() bool {
-	if len(p.unconfirmedMessages) == 0 {
+	p.lock.Lock()
+	count := len(p.unconfirmedMessages)
+	if len(p._notifyPublish) < 1 {
+		p.lock.Unlock()
+		return true
+	}
+	channel := p._notifyPublish[0].channel
+	p.lock.Unlock()
+	if count == 0 {
 		return true
 	}
 	for {
 		select {
-		case confirm := <-p._notifyPublish[0].channel:
+		case confirm := <-channel:
 			if !p.handleConfirmationMessage(confirm) {
 				return false
 			}
@@ -228,8 +287,12 @@ func (p *AssuredPublisher) handleConfirmationMessage(confirm amqp.Confirmation) 
 		log.Printf("Unknown Error (RabbitMQ Publisher's confirmation channel has been closed)")
 		return false
 	}
-	if p.confirmationHandler != nil {
-		p.confirmationHandler(confirm, p.unconfirmedMessages[confirm.DeliveryTag].arg)
+	p.lock.Lock()
+	confirmationHandler := p.confirmationHandler
+	arg := p.unconfirmedMessages[confirm.DeliveryTag].arg
+	p.lock.Unlock()
+	if confirmationHandler != nil {
+		confirmationHandler(confirm, arg)
 	}
 	if confirm.Ack || p.doNotRepublish {
 		p.forgetMessage(confirm.DeliveryTag)
@@ -242,21 +305,27 @@ func (p *AssuredPublisher) handleConfirmationMessage(confirm amqp.Confirmation) 
 
 // forgetMessage removes a message from the internal storage
 func (p *AssuredPublisher) forgetMessage(deliveryTag uint64) {
+	p.lock.Lock()
 	delete(p.unconfirmedMessages, deliveryTag)
+	p.lock.Unlock()
 }
 
 // WaitForAllConfirmations waits for all confirmations and retries publishing if needed.
 // Returns false only if is cancelled.
-func (p *AssuredPublisher) WaitForAllConfirmations(cancel <-chan bool) bool {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
+func (p *AssuredPublisher) WaitForAllConfirmations() bool {
+	p.publicMethodsLock.Lock()
+	defer p.publicMethodsLock.Unlock()
 	for {
+		p.lock.Lock()
 		if len(p.unconfirmedMessages) == 0 {
+			p.lock.Unlock()
 			return true
 		}
-		if !p.waitForConfirmation(cancel) {
+		p.lock.Unlock()
+		select {
+		case <-p.cancelChannel:
 			return false
+		case <-time.After(300 * time.Millisecond):
 		}
 	}
 }

--- a/pop_test.go
+++ b/pop_test.go
@@ -20,7 +20,7 @@ func TestPop(t *testing.T) {
 	assert := assert.New(t)
 
 	message := "Test Message"
-	rabbit.NewPublisher().Publish(message, &subscriber)
+	rabbit.NewPublisher(make(chan bool)).Publish(message, &subscriber)
 
 	rabbit.ResetPopConnection()
 	result, err := rabbit.Pop(&subscriber)

--- a/publisher.go
+++ b/publisher.go
@@ -22,6 +22,8 @@ type Publisher struct {
 	_reliableMode     bool
 	_reliableModeWait bool
 	lock              sync.Mutex
+	cancelChannel     <-chan bool
+	publicMethodsLock sync.Mutex
 }
 
 type notifyPublishSpec struct {
@@ -30,29 +32,46 @@ type notifyPublishSpec struct {
 }
 
 // NewPublisher constructs a new Publisher instance.
-func NewPublisher() *Publisher {
-	return &Publisher{connection: publisherConnection}
+func NewPublisher(cancelChannel <-chan bool) *Publisher {
+	return &Publisher{connection: publisherConnection, cancelChannel: cancelChannel}
 }
 
 // NewPublisherWithConnection constructs a new Publisher instance with a custom connection
-func NewPublisherWithConnection(connection *Connection) *Publisher {
-	return &Publisher{connection: connection}
+func NewPublisherWithConnection(connection *Connection, cancelChannel <-chan bool) *Publisher {
+	return &Publisher{connection: connection, cancelChannel: cancelChannel}
 }
 
 // GetChannel returns a publisher's channel. It opens a new channel if needed.
 func (p *Publisher) GetChannel() *amqp.Channel {
+	p.publicMethodsLock.Lock()
+	defer p.publicMethodsLock.Unlock()
+	return p.getChannelWithoutLock()
+}
+
+func (p *Publisher) getChannelWithoutLock() *amqp.Channel {
+	lock.Lock()
 	if p._channel != nil {
+		defer lock.Unlock()
 		return p._channel
 	}
+	lock.Unlock()
 	for {
+		p.lock.Lock()
 		if err := p.openChannel(); err == nil {
+			p.lock.Unlock()
 			break
 		} else {
 			logError(err, "Can't open a new RabbitMQ channel for publisher")
-			p.Close()
 		}
-		time.Sleep(1 * time.Second)
+		p.lock.Unlock()
+		select {
+		case <-p.cancelChannel:
+			return nil
+		case <-time.After(1 * time.Second):
+		}
 	}
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	return p._channel
 }
 
@@ -62,7 +81,6 @@ func (p *Publisher) openChannel() (err error) {
 
 	if err != nil {
 		errorMsg := fmt.Sprintf("Can't create a RabbitMQ channel for publisher: %+#v", err)
-		log.Print(errorMsg)
 		return errors.New(errorMsg)
 	}
 	for i := range p._notifyPublish {
@@ -72,33 +90,48 @@ func (p *Publisher) openChannel() (err error) {
 	}
 	if p._reliableMode {
 		if err := p._channel.Confirm(p._reliableModeWait); err != nil {
-			p.Close()
-			log.Printf("Error on enabling RabbitMQ confirmation on reconnecting: %s", err.Error())
+			log.Printf("Error on switching to reliable mode: closing channel")
+			p.closeWithoutLock()
 			return err
 		}
 	}
-
 	return nil
 }
 
 // Confirm enables reliable mode for the publisher.
 func (p *Publisher) Confirm(wait bool) error {
+	p.publicMethodsLock.Lock()
+	defer p.publicMethodsLock.Unlock()
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	channel := p.getChannelWithoutLock()
+	if channel == nil {
+		return errors.New("Cancelled")
+	}
 	p._reliableMode = true
 	p._reliableModeWait = wait
-	channel := p.GetChannel()
 	err := channel.Confirm(wait)
 	if err != nil {
-		log.Printf("Error on enabling RabbitMQ confirmation (will disconnect publisher): %s", err.Error())
-		p.Close()
+		log.Printf("Error on enabling RabbitMQ confirmation (will close channel): %s", err.Error())
+		p.closeWithoutLock()
 	}
 	return err
 }
 
 // NotifyPublish registers a listener for reliable publishing.
 func (p *Publisher) NotifyPublish(size int) chan amqp.Confirmation {
-	channel := p.GetChannel()
+	p.publicMethodsLock.Lock()
+	defer p.publicMethodsLock.Unlock()
+
+	channel := p.getChannelWithoutLock()
+	if channel == nil {
+		return nil
+	}
 	notifyChannel := make(chan amqp.Confirmation, size)
+	p.lock.Lock()
 	p._notifyPublish = append(p._notifyPublish, notifyPublishSpec{notifyChannel, size})
+	p.lock.Unlock()
 	channel.NotifyPublish(notifyChannel)
 	return notifyChannel
 }
@@ -110,15 +143,18 @@ func (p *Publisher) Publish(message string, subscriber *Subscriber) error {
 
 // PublishBytes is the same as Publish but accepts a []byte instead of a string
 func (p *Publisher) PublishBytes(message []byte, subscriber *Subscriber) error {
-	p.lock.Lock()
-	defer p.lock.Unlock()
+	p.publicMethodsLock.Lock()
+	defer p.publicMethodsLock.Unlock()
 
 	return p.publishBytesWithoutLock(message, subscriber)
 }
 
 // PublishBytes is the same as Publish but accepts a []byte instead of a string
 func (p *Publisher) publishBytesWithoutLock(message []byte, subscriber *Subscriber) error {
-	channel := p.GetChannel()
+	channel := p.getChannelWithoutLock()
+	if channel == nil {
+		return errors.New("Cancelled")
+	}
 
 	return channel.Publish(
 		subscriber.Exchange,   // exchange
@@ -134,13 +170,16 @@ func (p *Publisher) publishBytesWithoutLock(message []byte, subscriber *Subscrib
 
 //Close will close the connection and channel for the Publisher
 func (p *Publisher) Close() {
+	p.publicMethodsLock.Lock()
+	defer p.publicMethodsLock.Unlock()
+	p.closeWithoutLock()
+}
+
+func (p *Publisher) closeWithoutLock() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
 	if p._channel != nil {
 		p._channel.Close()
 		p._channel = nil
-	}
-	if p.connection != nil {
-		p.connection.Close()
-	} else if publisherConnection != nil {
-		publisherConnection.Close()
 	}
 }

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -19,7 +19,7 @@ func TestPublish(t *testing.T) {
 
 	recreateQueue(t, &subscriber)
 	message := "Test Message"
-	publisher := rabbit.NewPublisher()
+	publisher := rabbit.NewPublisher(make(chan bool))
 	publisher.Publish(message, &subscriber)
 
 	var result string
@@ -35,7 +35,7 @@ func TestConfirm(t *testing.T) {
 		Queue:       "test.confirmsample.event.created",
 		RoutingKey:  "confirmsample.event.created",
 	}
-	publisher := rabbit.NewPublisher()
+	publisher := rabbit.NewPublisher(make(chan bool))
 	confirms := publisher.NotifyPublish(1)
 	publisher.Confirm(false)
 	publisher.Publish("something", &subscriber)

--- a/rabbit_test.go
+++ b/rabbit_test.go
@@ -62,7 +62,7 @@ func TestNack(t *testing.T) {
 	}
 	rabbit.Register(subscriber, nackHandler)
 	rabbit.StartSubscribers()
-	rabbit.NewPublisher().Publish("{}", &subscriber)
+	rabbit.NewPublisher(make(chan bool)).Publish("{}", &subscriber)
 	for i := 0; i < 2; i++ {
 		select {
 		case <-done:
@@ -82,7 +82,7 @@ func TestStartingSubscribers(t *testing.T) {
 
 func recreateQueue(t *testing.T, subscriber *rabbit.Subscriber) {
 	done := make(chan bool)
-	publisher := rabbit.NewPublisher()
+	publisher := rabbit.NewPublisher(make(chan bool))
 	go func() {
 		for {
 			if _, err := publisher.GetChannel().QueueDelete(subscriber.Queue, false, false, true); err == nil {

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -65,7 +65,7 @@ func TestSubscribersReconnection(t *testing.T) {
 		RoutingKey:  "sample.event.created",
 	}
 	rabbit.CloseSubscribers()
-	rabbit.CreateQueue(rabbit.NewPublisher().GetChannel(), &subscriber)
+	rabbit.CreateQueue(rabbit.NewPublisher(make(chan bool)).GetChannel(), &subscriber)
 	recreateQueue(t, &subscriber)
 	rabbit.CloseSubscribers()
 	done := make(chan bool, 100)
@@ -80,7 +80,7 @@ func TestSubscribersReconnection(t *testing.T) {
 	rabbit.StartSubscribers()
 	connection := rabbit.NewConnectionWithURL(os.Getenv("RABBITMQ_URL"))
 	connection.ReplaceConnection(rabbit.ExposeSubscriberConnectionForTests())
-	publisher := rabbit.NewPublisherWithConnection(connection)
+	publisher := rabbit.NewPublisherWithConnection(connection, make(chan bool))
 	publisher.Publish("test", &subscriber)
 	select {
 	case <-done:
@@ -90,7 +90,7 @@ func TestSubscribersReconnection(t *testing.T) {
 	}
 	publisher.Close() // the subscriber should reconnect
 	timeoutChannel := time.After(5 * time.Second)
-	publisher = rabbit.NewPublisher()
+	publisher = rabbit.NewPublisher(make(chan bool))
 	for {
 		select {
 		case <-done:
@@ -125,7 +125,7 @@ func TestSubscribersWithManualAck(t *testing.T) {
 	}
 	rabbit.Register(subscriber, handler)
 	rabbit.StartSubscribers()
-	publisher := rabbit.NewPublisher()
+	publisher := rabbit.NewPublisher(make(chan bool))
 	publisher.Publish("test", &subscriber)
 	select {
 	case <-done:


### PR DESCRIPTION
* make each cycle with retries cancelable
* eliminate data races
* ensure that all public methods are single-threaded
* improve locking (+ eliminate dead locks)